### PR TITLE
config strings are read-only

### DIFF
--- a/include/bedrock/module.h
+++ b/include/bedrock/module.h
@@ -134,7 +134,7 @@ typedef int (*bedrock_destroy_provider_handle_fn)(
  *
  * @return null-terminated configuration string.
  */
-typedef char* (*bedrock_provider_get_config_fn)(bedrock_module_provider_t);
+typedef const char* (*bedrock_provider_get_config_fn)(bedrock_module_provider_t);
 
 /**
  * @brief Type of function called to get the configuration of a client.
@@ -144,7 +144,7 @@ typedef char* (*bedrock_provider_get_config_fn)(bedrock_module_provider_t);
  *
  * @return null-terminated configuration string.
  */
-typedef char* (*bedrock_client_get_config_fn)(bedrock_module_client_t);
+typedef const char* (*bedrock_client_get_config_fn)(bedrock_module_client_t);
 
 /**
  * @brief A global instance of the bedrock_module structure must be provided

--- a/src/DynLibServiceFactory.hpp
+++ b/src/DynLibServiceFactory.hpp
@@ -96,7 +96,7 @@ class DynLibServiceFactory : public AbstractServiceFactory {
         auto config = m_module.get_provider_config(provider);
         if (!config) return std::string("{}");
         auto config_str = std::string(config);
-        free(config);
+        free((void *)config);
         return config_str;
     }
 
@@ -123,7 +123,7 @@ class DynLibServiceFactory : public AbstractServiceFactory {
         auto config = m_module.get_client_config(client);
         if (!config) return std::string("{}");
         auto config_str = std::string(config);
-        free(config);
+        free((void *)config);
         return config_str;
     }
 


### PR DESCRIPTION
I should be using the C++ approach in my C++ code but I started with the C module.  Any harm in making these config gettters return const?   For example, if I try to return a json object as a string, the compiler warns about ignoring the `const`:

```
      json json_config;
      json_config["buffer_size"] = provider->bufsize;
      json_config["xfersize"] = provider->xfersize;
      return json_config.dump().c_str();
```
